### PR TITLE
Add quality-gated review selection

### DIFF
--- a/backend/api/core/conversation_manager.py
+++ b/backend/api/core/conversation_manager.py
@@ -29,6 +29,8 @@ except ImportError:
 
 SEED_MODULUS = 2 ** 32
 DEFAULT_FIXED_BASE_SEED = 1234
+DEFAULT_QUALITY_GATE_MIN_QUALITY_SCORE = 0.48
+DEFAULT_QUALITY_GATE_MIN_PACING_SCORE = 0.45
 
 class ConversationManager:
     """Manages multi-speaker conversation generation."""
@@ -133,6 +135,95 @@ class ConversationManager:
         except (TypeError, ValueError):
             numeric_seed = int(fallback)
         return numeric_seed % SEED_MODULUS
+
+    @staticmethod
+    def _normalize_score_threshold(value: Optional[Any], fallback: float) -> float:
+        """Clamp arbitrary score thresholds to the supported 0..1 range."""
+        try:
+            numeric_value = float(value)
+        except (TypeError, ValueError):
+            numeric_value = float(fallback)
+        return max(0.0, min(1.0, numeric_value))
+
+    @classmethod
+    def _evaluate_quality_gate(
+        cls,
+        *,
+        similarity_score: float,
+        robotic_score: float,
+        quality_score: float,
+        pacing_score: Optional[float],
+        similarity_threshold: float,
+        robotic_threshold: float,
+    ) -> Dict[str, Any]:
+        """Return whether a generated version is safe to auto-select."""
+        normalized_similarity_threshold = cls._normalize_score_threshold(similarity_threshold, 0.60)
+        normalized_robotic_threshold = cls._normalize_score_threshold(robotic_threshold, 0.70)
+        min_quality_score = max(
+            DEFAULT_QUALITY_GATE_MIN_QUALITY_SCORE,
+            round(normalized_similarity_threshold * 0.8, 3),
+        )
+        min_pacing_score = DEFAULT_QUALITY_GATE_MIN_PACING_SCORE
+        failures: List[str] = []
+
+        try:
+            safe_similarity = float(similarity_score)
+        except (TypeError, ValueError):
+            safe_similarity = -1.0
+        try:
+            safe_robotic = float(robotic_score)
+        except (TypeError, ValueError):
+            safe_robotic = 1.0
+        try:
+            safe_quality = float(quality_score)
+        except (TypeError, ValueError):
+            safe_quality = -1.0
+        try:
+            safe_pacing = None if pacing_score is None else float(pacing_score)
+        except (TypeError, ValueError):
+            safe_pacing = None
+
+        if safe_similarity < normalized_similarity_threshold:
+            failures.append(
+                f"Similarity {safe_similarity:.2f} is below the {normalized_similarity_threshold:.2f} gate."
+            )
+        if safe_robotic > normalized_robotic_threshold:
+            failures.append(
+                f"Robotic score {safe_robotic:.2f} is above the {normalized_robotic_threshold:.2f} gate."
+            )
+        if safe_quality < min_quality_score:
+            failures.append(
+                f"Quality {safe_quality:.2f} is below the {min_quality_score:.2f} floor."
+            )
+        if safe_pacing is not None and safe_pacing < min_pacing_score:
+            failures.append(
+                f"Pacing {safe_pacing:.2f} is below the {min_pacing_score:.2f} floor."
+            )
+
+        return {
+            "meets_quality_gate": not failures,
+            "quality_gate_failures": failures,
+        }
+
+    @classmethod
+    def _apply_quality_gate_metadata(
+        cls,
+        version_result: Dict[str, Any],
+        *,
+        similarity_threshold: float,
+        robotic_threshold: float,
+    ) -> Dict[str, Any]:
+        """Annotate a version payload with quality-gate metadata."""
+        gate_result = cls._evaluate_quality_gate(
+            similarity_score=version_result.get("similarity_score", -1.0),
+            robotic_score=version_result.get("robotic_score", 1.0),
+            quality_score=version_result.get("quality_score", -1.0),
+            pacing_score=version_result.get("pacing_score"),
+            similarity_threshold=similarity_threshold,
+            robotic_threshold=robotic_threshold,
+        )
+        version_result.update(gate_result)
+        return version_result
 
     @staticmethod
     def _build_version_result(
@@ -483,33 +574,39 @@ class ConversationManager:
                     if quality_score > best_score:
                         best_score = quality_score
                     
+                    version_result = self._apply_quality_gate_metadata(
+                        self._build_version_result(
+                            audio_path=audio_path,
+                            similarity_score=similarity_score,
+                            robotic_score=robotic_score,
+                            quality_score=quality_score,
+                            speaker_filename=speaker_file,
+                            text=text,
+                            emotion_vectors=line_emo_vector,
+                            emotion_control_method=line_emo_control_method,
+                            emotion_reference_filename=line_emo_ref_path,
+                            emotion_weight=line_emo_weight,
+                            emotion_text=line_emo_text,
+                            seed=current_seed,
+                            seed_origin="initial",
+                            seed_strategy=normalized_seed_strategy,
+                            delivery_rate=delivery_rate,
+                            duration_seconds=pacing_result["duration_seconds"],
+                            expected_duration_seconds=pacing_result["expected_duration_seconds"],
+                            pacing_score=pacing_result["pacing_score"],
+                            pacing_label=pacing_result["pacing_label"],
+                            pacing_notes=pacing_result["pacing_notes"],
+                            review_score=pacing_result["review_score"],
+                        ),
+                        similarity_threshold=similarity_threshold,
+                        robotic_threshold=robotic_threshold,
+                    )
+
                     # Always add the result to the list, regardless of threshold
-                    results.append(self._build_version_result(
-                        audio_path=audio_path,
-                        similarity_score=similarity_score,
-                        robotic_score=robotic_score,
-                        quality_score=quality_score,
-                        speaker_filename=speaker_file,
-                        text=text,
-                        emotion_vectors=line_emo_vector,
-                        emotion_control_method=line_emo_control_method,
-                        emotion_reference_filename=line_emo_ref_path,
-                        emotion_weight=line_emo_weight,
-                        emotion_text=line_emo_text,
-                        seed=current_seed,
-                        seed_origin="initial",
-                        seed_strategy=normalized_seed_strategy,
-                        delivery_rate=delivery_rate,
-                        duration_seconds=pacing_result["duration_seconds"],
-                        expected_duration_seconds=pacing_result["expected_duration_seconds"],
-                        pacing_score=pacing_result["pacing_score"],
-                        pacing_label=pacing_result["pacing_label"],
-                        pacing_notes=pacing_result["pacing_notes"],
-                        review_score=pacing_result["review_score"],
-                    ))
+                    results.append(version_result)
                     
                     # Check if quality meets threshold (considering both similarity and robotic score)
-                    if similarity_score >= similarity_threshold and robotic_score <= robotic_threshold:
+                    if version_result["meets_quality_gate"]:
                         line_success = True
                         status_log.append(f"  ✅ Version {attempt+1} meets quality threshold (similarity: {similarity_score:.2f}, robotic: {robotic_score:.2f})")
                         yield "\n".join(status_log), self._update_progress_bar(line_progress), line_progress, None, None
@@ -593,37 +690,42 @@ class ConversationManager:
                                     yield "\n".join(status_log), self._update_progress_bar(line_progress), line_progress, None, None
                                     
                                     if regen_quality_score > quality_score:
-                                        # Replace with better version
-                                        results[-1] = self._build_version_result(
-                                            audio_path=regen_audio_path,
-                                            similarity_score=regen_similarity,
-                                            robotic_score=regen_robotic,
-                                            quality_score=regen_quality_score,
-                                            speaker_filename=speaker_file,
-                                            text=text,
-                                            emotion_vectors=line_emo_vector,
-                                            emotion_control_method=line_emo_control_method,
-                                            emotion_reference_filename=line_emo_ref_path,
-                                            emotion_weight=line_emo_weight,
-                                            emotion_text=line_emo_text,
-                                            seed=regen_seed,
-                                            seed_origin="auto_regen",
-                                            seed_strategy=normalized_seed_strategy,
-                                            delivery_rate=delivery_rate,
-                                            duration_seconds=regen_pacing["duration_seconds"],
-                                            expected_duration_seconds=regen_pacing["expected_duration_seconds"],
-                                            pacing_score=regen_pacing["pacing_score"],
-                                            pacing_label=regen_pacing["pacing_label"],
-                                            pacing_notes=regen_pacing["pacing_notes"],
-                                            review_score=regen_pacing["review_score"],
+                                        regen_version_result = self._apply_quality_gate_metadata(
+                                            self._build_version_result(
+                                                audio_path=regen_audio_path,
+                                                similarity_score=regen_similarity,
+                                                robotic_score=regen_robotic,
+                                                quality_score=regen_quality_score,
+                                                speaker_filename=speaker_file,
+                                                text=text,
+                                                emotion_vectors=line_emo_vector,
+                                                emotion_control_method=line_emo_control_method,
+                                                emotion_reference_filename=line_emo_ref_path,
+                                                emotion_weight=line_emo_weight,
+                                                emotion_text=line_emo_text,
+                                                seed=regen_seed,
+                                                seed_origin="auto_regen",
+                                                seed_strategy=normalized_seed_strategy,
+                                                delivery_rate=delivery_rate,
+                                                duration_seconds=regen_pacing["duration_seconds"],
+                                                expected_duration_seconds=regen_pacing["expected_duration_seconds"],
+                                                pacing_score=regen_pacing["pacing_score"],
+                                                pacing_label=regen_pacing["pacing_label"],
+                                                pacing_notes=regen_pacing["pacing_notes"],
+                                                review_score=regen_pacing["review_score"],
+                                            ),
+                                            similarity_threshold=similarity_threshold,
+                                            robotic_threshold=robotic_threshold,
                                         )
+                                        # Replace with better version
+                                        results[-1] = regen_version_result
                                         similarity_score = regen_similarity
                                         robotic_score = regen_robotic
                                         quality_score = regen_quality_score
                                         status_log.append(f"    ✅ Improved to quality {regen_quality_score:.2f}")
                                         yield "\n".join(status_log), self._update_progress_bar(line_progress), line_progress, None, None
                                         
-                                        if regen_similarity >= similarity_threshold and regen_robotic <= robotic_threshold:
+                                        if regen_version_result["meets_quality_gate"]:
                                             line_success = True
                                             status_log.append(f"    ✅ Regen version meets quality threshold!")
                                             yield "\n".join(status_log), self._update_progress_bar(line_progress), line_progress, None, None
@@ -855,11 +957,17 @@ class ConversationManager:
         """Find the index of the highest quality result for a line."""
         if not line_results:
             return 0
-        
-        highest_index = 0
+
+        gated_indices = [
+            index for index, result in enumerate(line_results)
+            if result.get("meets_quality_gate", False)
+        ]
+        candidate_indices = gated_indices or list(range(len(line_results)))
+        highest_index = candidate_indices[0]
         highest_score = -1.0
-        
-        for i, result in enumerate(line_results):
+
+        for i in candidate_indices:
+            result = line_results[i]
             # Use quality_score if available, otherwise fallback to similarity_score
             score = result.get('quality_score', result.get('similarity_score', -1.0))
             if score > highest_score:

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -341,6 +341,8 @@ class LineVersion(BaseModel):
     robotic_score: float
     quality_score: float
     is_selected: bool = False
+    meets_quality_gate: Optional[bool] = None
+    quality_gate_failures: List[str] = Field(default_factory=list)
     seed: Optional[int] = None
     seed_origin: Optional[str] = None
     seed_strategy: Optional[str] = None

--- a/backend/api/routers/conversation_results.py
+++ b/backend/api/routers/conversation_results.py
@@ -58,9 +58,75 @@ def _normalize_version_payload(conversation_service: ConversationService, versio
     return normalized
 
 
-def _version_score(version: Optional[Dict[str, Any]]) -> float:
+def _resolve_quality_gate(generation_params: Optional[Dict[str, Any]] = None) -> Dict[str, float]:
+    """Resolve the thresholds used for auto-selecting acceptable versions."""
+    params = generation_params or {}
+    similarity_threshold = float(params.get("similarity_threshold", 0.60))
+    robotic_threshold = float(params.get("robotic_threshold", settings.robotic_threshold))
+    min_quality_score = float(
+        params.get("quality_gate_min_quality_score", max(0.48, round(similarity_threshold * 0.8, 3)))
+    )
+    min_pacing_score = float(params.get("quality_gate_min_pacing_score", 0.45))
+    return {
+        "similarity_threshold": max(0.0, min(1.0, similarity_threshold)),
+        "robotic_threshold": max(0.0, min(1.0, robotic_threshold)),
+        "min_quality_score": max(0.0, min(1.0, min_quality_score)),
+        "min_pacing_score": max(0.0, min(1.0, min_pacing_score)),
+    }
+
+
+def _version_meets_quality_gate(
+    version: Optional[Dict[str, Any]],
+    quality_gate: Optional[Dict[str, float]] = None,
+) -> bool:
+    """Return whether a version is safe to auto-select."""
+    if not isinstance(version, dict):
+        return False
+
+    explicit_gate = version.get("meets_quality_gate")
+    if isinstance(explicit_gate, bool):
+        return explicit_gate
+
+    gate = quality_gate or _resolve_quality_gate()
+    try:
+        similarity_score = float(version.get("similarity_score", -1.0))
+    except (TypeError, ValueError):
+        similarity_score = -1.0
+    try:
+        robotic_score = float(version.get("robotic_score", 1.0))
+    except (TypeError, ValueError):
+        robotic_score = 1.0
+    try:
+        quality_score = float(version.get("quality_score", similarity_score))
+    except (TypeError, ValueError):
+        quality_score = similarity_score
+    pacing_score = version.get("pacing_score")
+    try:
+        safe_pacing = None if pacing_score is None else float(pacing_score)
+    except (TypeError, ValueError):
+        safe_pacing = None
+
+    if similarity_score < gate["similarity_threshold"]:
+        return False
+    if robotic_score > gate["robotic_threshold"]:
+        return False
+    if quality_score < gate["min_quality_score"]:
+        return False
+    if safe_pacing is not None and safe_pacing < gate["min_pacing_score"]:
+        return False
+    return True
+
+
+def _version_score(
+    version: Optional[Dict[str, Any]],
+    quality_gate: Optional[Dict[str, float]] = None,
+    *,
+    require_quality_gate: bool = False,
+) -> float:
     """Compare versions using the same quality-first ordering as the UI."""
     if not isinstance(version, dict):
+        return float("-inf")
+    if require_quality_gate and not _version_meets_quality_gate(version, quality_gate):
         return float("-inf")
     return float(
         version.get(
@@ -70,11 +136,16 @@ def _version_score(version: Optional[Dict[str, Any]]) -> float:
     )
 
 
-def _best_version_index(versions: List[Dict[str, Any]]) -> int:
-    """Return the index of the highest scoring version."""
-    best_index = 0
+def _best_gate_passing_version_index(
+    versions: List[Dict[str, Any]],
+    quality_gate: Optional[Dict[str, float]] = None,
+) -> Optional[int]:
+    """Return the highest-scoring version that clears the quality gate."""
+    best_index: Optional[int] = None
     best_score = float("-inf")
     for index, version in enumerate(versions):
+        if not _version_meets_quality_gate(version, quality_gate):
+            continue
         score = _version_score(version)
         if score > best_score:
             best_index = index
@@ -82,17 +153,69 @@ def _best_version_index(versions: List[Dict[str, Any]]) -> int:
     return best_index
 
 
-def _ensure_single_selection(versions: List[Dict[str, Any]], preferred_index: Optional[int] = None) -> List[Dict[str, Any]]:
+def _best_version_index(
+    versions: List[Dict[str, Any]],
+    quality_gate: Optional[Dict[str, float]] = None,
+    *,
+    require_quality_gate: bool = False,
+) -> Optional[int]:
+    """Return the best version, preferring gate-passing results when requested."""
+    if require_quality_gate:
+        best_gate_passing = _best_gate_passing_version_index(versions, quality_gate)
+        if best_gate_passing is not None:
+            return best_gate_passing
+
+    best_index: Optional[int] = None
+    best_score = float("-inf")
+    for index, version in enumerate(versions):
+        score = _version_score(version, quality_gate)
+        if score > best_score:
+            best_index = index
+            best_score = score
+    return best_index
+
+
+def _ensure_single_selection(
+    versions: List[Dict[str, Any]],
+    preferred_index: Optional[int] = None,
+    quality_gate: Optional[Dict[str, float]] = None,
+    *,
+    require_quality_gate: bool = False,
+) -> List[Dict[str, Any]]:
     """Keep version selection stable and guarantee at most one selected item."""
     if not versions:
         return versions
 
     selected_indices = [index for index, version in enumerate(versions) if version.get("is_selected")]
     if preferred_index is None:
-        preferred_index = selected_indices[0] if selected_indices else _best_version_index(versions)
+        if selected_indices:
+            preferred_index = selected_indices[0]
+            if require_quality_gate and not _version_meets_quality_gate(versions[preferred_index], quality_gate):
+                preferred_index = _best_version_index(
+                    versions,
+                    quality_gate,
+                    require_quality_gate=True,
+                )
+        else:
+            preferred_index = _best_version_index(
+                versions,
+                quality_gate,
+                require_quality_gate=require_quality_gate,
+            )
+    elif (
+        require_quality_gate
+        and preferred_index is not None
+        and 0 <= preferred_index < len(versions)
+        and not _version_meets_quality_gate(versions[preferred_index], quality_gate)
+    ):
+        preferred_index = _best_version_index(
+            versions,
+            quality_gate,
+            require_quality_gate=require_quality_gate,
+        )
 
     for index, version in enumerate(versions):
-        version["is_selected"] = index == preferred_index
+        version["is_selected"] = preferred_index is not None and index == preferred_index
     return versions
 
 
@@ -101,6 +224,7 @@ def _merge_threshold_versions(
     existing_versions: List[Dict[str, Any]],
     regenerated_versions: List[Dict[str, Any]],
     slots_to_regenerate: List[int],
+    quality_gate: Optional[Dict[str, float]] = None,
 ) -> List[Dict[str, Any]]:
     """Keep the best version in each slot while preserving slot order."""
     updated_versions: List[Dict[str, Any]] = []
@@ -119,18 +243,30 @@ def _merge_threshold_versions(
             )
             regenerated_index += 1
             chosen_version = candidate if _version_score(candidate) > _version_score(existing_version) else existing_version
+            preserve_selection = bool(
+                selected_before
+                and (
+                    chosen_version is existing_version
+                    or _version_meets_quality_gate(chosen_version, quality_gate)
+                )
+            )
         else:
             chosen_version = existing_version
+            preserve_selection = selected_before
 
         normalized = _normalize_version_payload(
             conversation_service,
             chosen_version,
-            is_selected=selected_before,
+            is_selected=preserve_selection,
         )
         if normalized:
             updated_versions.append(normalized)
 
-    return _ensure_single_selection(updated_versions)
+    return _ensure_single_selection(
+        updated_versions,
+        quality_gate=quality_gate,
+        require_quality_gate=True,
+    )
 
 
 @router.get("/{conversation_id}/results")
@@ -761,6 +897,7 @@ async def regenerate_line_background(
         # such as per-line emotion vectors from the parsed script.
         conversation_task = conversation_service.active_conversations.get(conversation_id, {})
         generation_params = conversation_task.get("generation_params", {})
+        quality_gate = _resolve_quality_gate(generation_params)
         parsed_script = conversation_task.get("parsed_script", [])
         current_lines = conversation_task.get("lines", [])
 
@@ -874,6 +1011,7 @@ async def regenerate_line_background(
                     existing_versions,
                     regenerated_versions,
                     slots_to_regenerate,
+                    quality_gate=quality_gate,
                 )
             else:
                 updated_versions = [
@@ -885,7 +1023,11 @@ async def regenerate_line_background(
                     for version in existing_versions
                 ]
                 updated_versions = [version for version in updated_versions if version]
-                updated_versions = _ensure_single_selection(updated_versions)
+                updated_versions = _ensure_single_selection(
+                    updated_versions,
+                    quality_gate=quality_gate,
+                    require_quality_gate=True,
+                )
                 task["current_step"] = "No versions were below the manual threshold"
 
         else:
@@ -909,7 +1051,11 @@ async def regenerate_line_background(
                 for version in regenerated_versions
             ]
             updated_versions = [version for version in updated_versions if version]
-            updated_versions = _ensure_single_selection(updated_versions)
+            updated_versions = _ensure_single_selection(
+                updated_versions,
+                quality_gate=quality_gate,
+                require_quality_gate=True,
+            )
 
         task["new_versions"] = updated_versions
 

--- a/backend/api/services/conversation_service.py
+++ b/backend/api/services/conversation_service.py
@@ -22,6 +22,8 @@ from ..core.file_utils import SAVE_DIR
 
 SEED_MODULUS = 2 ** 32
 DEFAULT_FIXED_BASE_SEED = 1234
+DEFAULT_QUALITY_GATE_MIN_QUALITY_SCORE = 0.48
+DEFAULT_QUALITY_GATE_MIN_PACING_SCORE = 0.45
 
 
 class ConversationService:
@@ -745,6 +747,11 @@ class ConversationService:
                 "versions_per_line": versions_per_line,
                 "similarity_threshold": similarity_threshold,
                 "robotic_threshold": robotic_threshold,
+                "quality_gate_min_quality_score": max(
+                    DEFAULT_QUALITY_GATE_MIN_QUALITY_SCORE,
+                    round(float(similarity_threshold) * 0.8, 3),
+                ),
+                "quality_gate_min_pacing_score": DEFAULT_QUALITY_GATE_MIN_PACING_SCORE,
                 "auto_regen_attempts": auto_regen_attempts,
                 "emotion_control_method": emotion_control_method,
                 "emotion_reference_filename": emotion_reference_filename,

--- a/frontend/assets/css/components.css
+++ b/frontend/assets/css/components.css
@@ -1582,6 +1582,11 @@ body.dark-mode .speaker-prep-metric-value {
     color: #0f766e;
 }
 
+.line-selection-quality-review {
+    background: rgba(249, 115, 22, 0.14);
+    color: #c2410c;
+}
+
 .line-selection-missing,
 .line-selection-invalid {
     background: rgba(245, 158, 11, 0.12);
@@ -1610,6 +1615,11 @@ body.dark-mode .selection-readiness-summary.is-ready,
 body.dark-mode .line-selection-ready {
     color: #6ee7b7;
     border-color: rgba(16, 185, 129, 0.3);
+}
+
+body.dark-mode .line-selection-quality-review {
+    color: #fdba74;
+    border-color: rgba(249, 115, 22, 0.32);
 }
 
 body.dark-mode .selection-readiness-summary.is-blocked,

--- a/frontend/assets/css/workflows.css
+++ b/frontend/assets/css/workflows.css
@@ -291,6 +291,11 @@
     background-color: var(--primary-light);
 }
 
+.version-item.quality-gate-failed {
+    border-color: rgba(249, 115, 22, 0.34);
+    background-color: rgba(255, 237, 213, 0.62);
+}
+
 .version-header {
     display: flex;
     justify-content: space-between;
@@ -329,6 +334,11 @@
 .score-badge.quality {
     background-color: #dcfce7;
     color: var(--success-color);
+}
+
+.score-badge.warning {
+    background-color: #ffedd5;
+    color: #c2410c;
 }
 
 .version-actions {
@@ -447,6 +457,11 @@ body.dark-mode .version-item.selected {
     background-color: var(--dm-primary-light);
 }
 
+body.dark-mode .version-item.quality-gate-failed {
+    border-color: rgba(249, 115, 22, 0.44);
+    background-color: rgba(124, 45, 18, 0.3);
+}
+
 body.dark-mode .version-title {
     color: var(--dm-gray-900);
 }
@@ -463,6 +478,11 @@ body.dark-mode .score-badge.similarity {
 body.dark-mode .score-badge.quality {
     background-color: #064e3b;
     color: var(--dm-success-color);
+}
+
+body.dark-mode .score-badge.warning {
+    background-color: rgba(154, 52, 18, 0.7);
+    color: #fdba74;
 }
 
 body.dark-mode .concatenation-info {

--- a/frontend/src/modules/conversationResults.js
+++ b/frontend/src/modules/conversationResults.js
@@ -29,6 +29,91 @@ function formatPacingLabel(label) {
         .replace(/\b\w/g, character => character.toUpperCase());
 }
 
+function getConversationQualityGateSettings(generationParams = {}) {
+    const similarityThreshold = Number.isFinite(Number(generationParams?.similarity_threshold))
+        ? Number(generationParams.similarity_threshold)
+        : 0.6;
+    const roboticThreshold = Number.isFinite(Number(generationParams?.robotic_threshold))
+        ? Number(generationParams.robotic_threshold)
+        : 0.7;
+    const minQualityScore = Number.isFinite(Number(generationParams?.quality_gate_min_quality_score))
+        ? Number(generationParams.quality_gate_min_quality_score)
+        : Math.max(0.48, similarityThreshold * 0.8);
+    const minPacingScore = Number.isFinite(Number(generationParams?.quality_gate_min_pacing_score))
+        ? Number(generationParams.quality_gate_min_pacing_score)
+        : 0.45;
+
+    return {
+        similarityThreshold,
+        roboticThreshold,
+        minQualityScore,
+        minPacingScore,
+    };
+}
+
+function conversationVersionMeetsQualityGate(version, generationParams = {}) {
+    if (!version || typeof version !== 'object') {
+        return false;
+    }
+
+    if (typeof version.meets_quality_gate === 'boolean') {
+        return version.meets_quality_gate;
+    }
+
+    const gate = getConversationQualityGateSettings(generationParams);
+    const similarityScore = Number(version.similarity_score);
+    const roboticScore = Number(version.robotic_score);
+    const qualityScore = Number.isFinite(Number(version.quality_score))
+        ? Number(version.quality_score)
+        : similarityScore;
+    const pacingScore = Number.isFinite(Number(version.pacing_score))
+        ? Number(version.pacing_score)
+        : null;
+
+    if (!Number.isFinite(similarityScore) || similarityScore < gate.similarityThreshold) {
+        return false;
+    }
+    if (!Number.isFinite(roboticScore) || roboticScore > gate.roboticThreshold) {
+        return false;
+    }
+    if (!Number.isFinite(qualityScore) || qualityScore < gate.minQualityScore) {
+        return false;
+    }
+    if (pacingScore !== null && pacingScore < gate.minPacingScore) {
+        return false;
+    }
+    return true;
+}
+
+function getBestConversationVersionIndex(line, generationParams = {}, { requireQualityGate = false } = {}) {
+    const versions = line?.versions || [];
+    let bestGatePassingVersionIndex = -1;
+    let bestGatePassingScore = Number.NEGATIVE_INFINITY;
+    let bestVersionIndex = -1;
+    let bestScore = Number.NEGATIVE_INFINITY;
+
+    versions.forEach((version, index) => {
+        const reviewScore = getConversationReviewScore(version);
+        const meetsQualityGate = conversationVersionMeetsQualityGate(version, generationParams);
+
+        if (meetsQualityGate && reviewScore > bestGatePassingScore) {
+            bestGatePassingScore = reviewScore;
+            bestGatePassingVersionIndex = index;
+        }
+
+        if (reviewScore > bestScore) {
+            bestScore = reviewScore;
+            bestVersionIndex = index;
+        }
+    });
+
+    if (requireQualityGate && bestGatePassingVersionIndex >= 0) {
+        return bestGatePassingVersionIndex;
+    }
+
+    return bestVersionIndex;
+}
+
 IndexTTSApp.prototype.loadListeningReviewsState = function() {
     try {
         const saved = localStorage.getItem('indexttsListeningReviews');
@@ -470,6 +555,9 @@ IndexTTSApp.prototype.loadConversations = async function() {
         this.conversations = response.details.conversations;
         console.log('DEBUG: conversations loaded:', this.conversations);
         this.renderConversations();
+        if (typeof this.refreshStudioShell === 'function') {
+            this.refreshStudioShell();
+        }
     } catch (error) {
         console.error('Failed to load conversations:', error);
     }
@@ -534,6 +622,9 @@ IndexTTSApp.prototype.selectConversation = async function(conversationId) {
     
     // Load conversation results
     await this.loadConversationResults(conversationId);
+    if (typeof this.refreshStudioShell === 'function') {
+        this.refreshStudioShell();
+    }
 };
 
 IndexTTSApp.prototype.loadConversationResults = async function(conversationId) {
@@ -565,6 +656,9 @@ IndexTTSApp.prototype.loadConversationResults = async function(conversationId) {
         this.renderLineVersions();
         this.refreshListeningFeedbackExport();
         this.refreshSeedReportExport();
+        if (typeof this.refreshStudioShell === 'function') {
+            this.refreshStudioShell();
+        }
         
     } catch (error) {
         console.error('DEBUG: loadConversationResults error:', error);
@@ -592,9 +686,12 @@ IndexTTSApp.prototype.getConversationSelectionStatus = function() {
         totalLines: this.currentConversationData.lines.length,
         selectedLines: 0,
         missingLines: [],
+        qualityWarningLines: [],
         multiSelectedLines: [],
         canExport: false,
     };
+
+    const generationParams = this.currentConversationData?.generation_params || {};
 
     this.currentConversationData.lines.forEach((line, lineIndex) => {
         const selectedVersions = (line.versions || []).filter(version => Boolean(version.is_selected));
@@ -604,6 +701,9 @@ IndexTTSApp.prototype.getConversationSelectionStatus = function() {
 
         if (selectedVersions.length === 1) {
             summary.selectedLines += 1;
+            if (!conversationVersionMeetsQualityGate(selectedVersions[0], generationParams)) {
+                summary.qualityWarningLines.push(lineNumber);
+            }
         } else if (selectedVersions.length === 0) {
             summary.missingLines.push(lineNumber);
         } else {
@@ -630,6 +730,10 @@ IndexTTSApp.prototype.buildSelectionReadinessMessage = function(selectionStatus)
     }
     if (selectionStatus.multiSelectedLines.length) {
         issues.push(`fix multiple selections on lines ${selectionStatus.multiSelectedLines.join(', ')}`);
+    }
+
+    if (!issues.length && selectionStatus.qualityWarningLines.length) {
+        return `Ready to export, but review low-quality selections on lines ${selectionStatus.qualityWarningLines.join(', ')}.`;
     }
 
     if (!issues.length) {
@@ -705,6 +809,7 @@ IndexTTSApp.prototype.renderLineVersions = function() {
         
         const lineItem = document.createElement('div');
         lineItem.className = 'line-item';
+        const generationParams = this.currentConversationData?.generation_params || {};
         const speakerLabel = escapeConversationResultsHtml((line.speaker_filename || 'Unknown').replace(/\.(wav|mp3)$/i, ''));
         const displayText = escapeConversationResultsHtml(line.text || '');
         const reviewText = escapeConversationResultsHtml(line.edited_text ?? line.text ?? '');
@@ -715,16 +820,31 @@ IndexTTSApp.prototype.renderLineVersions = function() {
             ? Number(line.max_manual_attempts)
             : parseInt(document.getElementById('auto-regen-attempts')?.value || '1', 10);
         const selectedVersionCount = (line.versions || []).filter(version => Boolean(version.is_selected)).length;
+        const hasGatePassingVersion = (line.versions || []).some(version => (
+            conversationVersionMeetsQualityGate(version, generationParams)
+        ));
+        const selectedVersion = (line.versions || []).find(version => Boolean(version.is_selected));
+        const selectedVersionNeedsReview = selectedVersionCount === 1 && !conversationVersionMeetsQualityGate(selectedVersion, generationParams);
         const selectionState = selectedVersionCount === 1
-            ? {
-                className: 'line-selection-ready',
-                label: 'Final version selected',
-            }
-            : selectedVersionCount === 0
+            ? selectedVersionNeedsReview
                 ? {
-                    className: 'line-selection-missing',
-                    label: 'Selection required',
+                    className: 'line-selection-quality-review',
+                    label: 'Selected, review recommended',
                 }
+                : {
+                    className: 'line-selection-ready',
+                    label: 'Final version selected',
+                }
+            : selectedVersionCount === 0
+                ? hasGatePassingVersion
+                    ? {
+                        className: 'line-selection-missing',
+                        label: 'Selection required',
+                    }
+                    : {
+                        className: 'line-selection-quality-review',
+                        label: 'Needs quality review',
+                    }
                 : {
                     className: 'line-selection-invalid',
                     label: 'Only one version can be selected',
@@ -747,11 +867,15 @@ IndexTTSApp.prototype.renderLineVersions = function() {
             const durationText = Number.isFinite(Number(version.duration_seconds))
                 ? `${Number(version.duration_seconds).toFixed(2)}s`
                 : 'n/a';
+            const meetsQualityGate = conversationVersionMeetsQualityGate(version, generationParams);
+            const qualityGateReason = Array.isArray(version.quality_gate_failures) && version.quality_gate_failures.length
+                ? escapeConversationResultsHtml(version.quality_gate_failures[0])
+                : 'Below the automatic quality gate.';
             
             console.log(`DEBUG: Version ${versionIndex}:`, version);
             
             return `
-                <div class="version-item ${isSelected ? 'selected' : ''}"
+                <div class="version-item ${isSelected ? 'selected' : ''} ${meetsQualityGate ? '' : 'quality-gate-failed'}"
                      onclick="app.selectVersion(${lineIndex}, ${versionIndex})">
                     <div class="version-header">
                         <span class="version-title">Version ${versionIndex + 1}</span>
@@ -760,10 +884,11 @@ IndexTTSApp.prototype.renderLineVersions = function() {
                             <span class="score-badge similarity">Similarity: ${similarityScore}%</span>
                             <span class="score-badge quality">Quality: ${qualityScore}%</span>
                             ${pacingScore !== null ? `<span class="score-badge similarity">Pacing: ${pacingScore}%</span>` : ''}
+                            ${meetsQualityGate ? '' : `<span class="score-badge warning" title="${qualityGateReason}">Needs review</span>`}
                         </div>
                     </div>
                     <div class="version-seed">${escapeConversationResultsHtml(seedText)}${seedOriginText ? ` | ${seedOriginText}` : ''}</div>
-                    <div class="version-seed">Duration ${escapeConversationResultsHtml(durationText)} | ${pacingLabel}${pacingNote ? ` | ${pacingNote}` : ''}</div>
+                    <div class="version-seed">Duration ${escapeConversationResultsHtml(durationText)} | ${pacingLabel}${pacingNote ? ` | ${pacingNote}` : ''}${meetsQualityGate ? '' : ` | ${qualityGateReason}`}</div>
                     <div class="version-actions">
                         <button class="btn btn-secondary btn-small"
                                 onclick="event.stopPropagation(); app.playVersionAudio('${version.audio_path}', '${version.audio_url || ''}')">
@@ -902,53 +1027,70 @@ IndexTTSApp.prototype.selectVersion = function(lineIndex, versionIndex) {
 
 IndexTTSApp.prototype.autoSelectBestVersions = function() {
     if (!this.currentConversationData) return;
-    
-    this.currentConversationData.lines.forEach(line => {
-        // Find version with highest review score
-        let bestVersionIndex = 0;
-        let bestScore = Number.NEGATIVE_INFINITY;
-        
+
+    const warningLines = [];
+    const generationParams = this.currentConversationData?.generation_params || {};
+
+    this.currentConversationData.lines.forEach((line, lineIndex) => {
+        const bestVersionIndex = getBestConversationVersionIndex(
+            line,
+            generationParams,
+            { requireQualityGate: true },
+        );
+
         line.versions.forEach((version, index) => {
-            const reviewScore = getConversationReviewScore(version);
-            if (reviewScore > bestScore) {
-                bestScore = reviewScore;
-                bestVersionIndex = index;
-            }
+            version.is_selected = (bestVersionIndex >= 0) && (index === bestVersionIndex);
         });
-        
-        // Select best version
-        line.versions.forEach((version, index) => {
-            version.is_selected = (index === bestVersionIndex);
-        });
+
+        if (bestVersionIndex >= 0 && !conversationVersionMeetsQualityGate(line.versions[bestVersionIndex], generationParams)) {
+            const lineNumber = Number.isFinite(Number(line.line_number))
+                ? Number(line.line_number) + 1
+                : lineIndex + 1;
+            warningLines.push(lineNumber);
+        }
     });
     
     this.renderLineVersions();
-    this.showNotification('Success', 'Auto-selected best versions', 'success');
+
+    if (warningLines.length) {
+        this.showNotification(
+            'Warning',
+            `Auto-selected the best available versions, but lines ${warningLines.join(', ')} still need review.`,
+            'warning',
+        );
+        return;
+    }
+
+    this.showNotification('Success', 'Auto-selected the best gate-passing versions', 'success');
 };
 
 IndexTTSApp.prototype.autoSelectBestForLine = function(lineIndex) {
     if (!this.currentConversationData) return;
     
     const line = this.currentConversationData.lines[lineIndex];
-    
-    // Find version with highest review score
-    let bestVersionIndex = 0;
-    let bestScore = Number.NEGATIVE_INFINITY;
-    
+    const generationParams = this.currentConversationData?.generation_params || {};
+    const bestVersionIndex = getBestConversationVersionIndex(
+        line,
+        generationParams,
+        { requireQualityGate: true },
+    );
+
     line.versions.forEach((version, index) => {
-        const reviewScore = getConversationReviewScore(version);
-        if (reviewScore > bestScore) {
-            bestScore = reviewScore;
-            bestVersionIndex = index;
-        }
-    });
-    
-    // Select best version
-    line.versions.forEach((version, index) => {
-        version.is_selected = (index === bestVersionIndex);
+        version.is_selected = (bestVersionIndex >= 0) && (index === bestVersionIndex);
     });
     
     this.renderLineVersions();
+
+    if (bestVersionIndex >= 0 && !conversationVersionMeetsQualityGate(line.versions[bestVersionIndex], generationParams)) {
+        const lineNumber = Number.isFinite(Number(line.line_number))
+            ? Number(line.line_number) + 1
+            : lineIndex + 1;
+        this.showNotification(
+            'Warning',
+            `Line ${lineNumber} picked the best available version, but it still needs review.`,
+            'warning',
+        );
+    }
 };
 
 IndexTTSApp.prototype.clearVersionSelections = function() {

--- a/tests/backend/test_review_regeneration_contract.py
+++ b/tests/backend/test_review_regeneration_contract.py
@@ -143,6 +143,90 @@ class ReviewRegenerationContractTests(unittest.TestCase):
         self.assertTrue(versions[1]["is_selected"])
         self.assertFalse(versions[0]["is_selected"])
 
+    def test_replace_all_regeneration_keeps_best_available_selection_when_all_versions_fail_quality_gate(self):
+        manager = RecordingConversationManager(
+            [
+                [
+                    {
+                        "audio_path": "temp_conversation_segments/fail_v1.wav",
+                        "similarity_score": 0.41,
+                        "robotic_score": 0.25,
+                        "quality_score": 0.36,
+                        "speaker_filename": "speaker.wav",
+                        "text": "Updated hello",
+                    },
+                    {
+                        "audio_path": "temp_conversation_segments/fail_v2.wav",
+                        "similarity_score": 0.53,
+                        "robotic_score": 0.25,
+                        "quality_score": 0.44,
+                        "speaker_filename": "speaker.wav",
+                        "text": "Updated hello",
+                    },
+                ]
+            ]
+        )
+        service = ConversationService(conversation_manager=manager)
+        service.active_conversations["conversation-1"] = {
+            "parsed_script": [
+                {
+                    "speaker_filename": "speaker.wav",
+                    "text": "Hello world",
+                    "line_number": 0,
+                    "emotion_vectors": LINE_EMOTION_VECTOR,
+                }
+            ],
+            "generation_params": build_generation_params(),
+            "lines": [
+                {
+                    "line_number": 0,
+                    "speaker_filename": "speaker.wav",
+                    "text": "Hello world",
+                    "versions": [
+                        {
+                            "audio_path": "temp_conversation_segments/original.wav",
+                            "similarity_score": 0.65,
+                            "robotic_score": 0.12,
+                            "quality_score": 0.52,
+                            "is_selected": True,
+                        }
+                    ],
+                }
+            ],
+        }
+        service.active_conversations["regen_conversation-1_0"] = {
+            "status": "pending",
+            "progress": 0.0,
+            "current_step": "Initializing regeneration",
+            "line_number": 0,
+            "regen_count": 2,
+            "conversation_id": "conversation-1",
+            "mode": "replace_all",
+            "edited_text": "Updated hello",
+            "manual_similarity_threshold": None,
+            "max_manual_attempts": None,
+            "error": None,
+            "start_time": 0.0,
+            "end_time": None,
+            "new_versions": [],
+        }
+
+        asyncio.run(
+            regenerate_line_background(
+                regen_task_id="regen_conversation-1_0",
+                conversation_id="conversation-1",
+                line_number=0,
+                regen_count=2,
+                line_data={"speaker_filename": "speaker.wav", "text": "Hello world"},
+                conversation_service=service,
+            )
+        )
+
+        versions = service.active_conversations["conversation-1"]["lines"][0]["versions"]
+        self.assertEqual(len(versions), 2)
+        self.assertFalse(versions[0]["is_selected"])
+        self.assertTrue(versions[1]["is_selected"])
+
     def test_threshold_regeneration_only_replaces_low_similarity_slots(self):
         manager = RecordingConversationManager(
             [

--- a/tests/backend/test_selection_gating_contract.py
+++ b/tests/backend/test_selection_gating_contract.py
@@ -4,6 +4,10 @@ from backend.api.routers.conversation import (
     summarize_line_selection_state,
     build_selection_gating_message,
 )
+from backend.api.routers.conversation_results import (
+    _ensure_single_selection,
+    _resolve_quality_gate,
+)
 
 
 class SelectionGatingContractTests(unittest.TestCase):
@@ -72,6 +76,62 @@ class SelectionGatingContractTests(unittest.TestCase):
         self.assertEqual(summary["selected_line_count"], 2)
         self.assertEqual(summary["missing_line_numbers"], [])
         self.assertEqual(summary["multi_selected_line_numbers"], [])
+
+    def test_quality_gate_auto_selection_falls_back_to_best_available_when_all_versions_fail(self):
+        versions = [
+            {
+                "similarity_score": 0.42,
+                "robotic_score": 0.25,
+                "quality_score": 0.38,
+                "pacing_score": 0.50,
+                "is_selected": False,
+            },
+            {
+                "similarity_score": 0.51,
+                "robotic_score": 0.25,
+                "quality_score": 0.44,
+                "pacing_score": 0.52,
+                "is_selected": False,
+            },
+        ]
+
+        updated_versions = _ensure_single_selection(
+            versions,
+            quality_gate=_resolve_quality_gate({"similarity_threshold": 0.60, "robotic_threshold": 0.70}),
+            require_quality_gate=True,
+        )
+
+        self.assertFalse(updated_versions[0]["is_selected"])
+        self.assertTrue(updated_versions[1]["is_selected"])
+
+    def test_quality_gate_auto_selection_prefers_best_passing_version(self):
+        versions = [
+            {
+                "similarity_score": 0.42,
+                "robotic_score": 0.25,
+                "quality_score": 0.38,
+                "pacing_score": 0.50,
+                "review_score": 0.41,
+                "is_selected": False,
+            },
+            {
+                "similarity_score": 0.82,
+                "robotic_score": 0.25,
+                "quality_score": 0.74,
+                "pacing_score": 0.91,
+                "review_score": 0.77,
+                "is_selected": False,
+            },
+        ]
+
+        updated_versions = _ensure_single_selection(
+            versions,
+            quality_gate=_resolve_quality_gate({"similarity_threshold": 0.60, "robotic_threshold": 0.70}),
+            require_quality_gate=True,
+        )
+
+        self.assertFalse(updated_versions[0]["is_selected"])
+        self.assertTrue(updated_versions[1]["is_selected"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a quality gate for auto-selected conversation versions so selection prefers results that pass similarity, robotic, quality, and pacing checks
- carry the quality-gate metadata through the backend regeneration flow and result payloads
- surface review-needed states in the conversation results UI when the best available take still needs human review
- add focused contract coverage for regeneration fallback and quality-gated selection behavior

## Validation
- docker compose -f docker/docker-compose.yml -f docker/docker-compose.gpu.yml exec backend python3 tests/backend/test_review_regeneration_contract.py
- docker compose -f docker/docker-compose.yml -f docker/docker-compose.gpu.yml exec backend python3 tests/backend/test_selection_gating_contract.py
- node --check frontend/src/modules/conversationResults.js
