### PR TITLE
Update public beta launcher to beta 8

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Copy to .env only if you want to override defaults.
 
 DRAFT_TO_TAKE_IMAGE_PREFIX=ghcr.io/jayspiffy
-DRAFT_TO_TAKE_IMAGE_TAG=v3.0.0-beta.7
+DRAFT_TO_TAKE_IMAGE_TAG=v3.0.0-beta.8
 
 # start.bat sets DRAFT_TO_TAKE_SHARED_DIR to:
 # %USERPROFILE%\DraftToTake\shared
@@ -43,9 +43,9 @@ OMNIVOICE_MODEL_ID=k2-fsa/OmniVoice
 OMNIVOICE_AUTO_DOWNLOAD=true
 OMNIVOICE_DOWNLOAD_ON_START=true
 
-# Optional SFX/music sidecar. It is off by default in the beta launcher because
-# the current default model-backed generators are license-dependent and heavier.
-INDTEXTS_SFX_ENABLED=false
+# Full Studio sound-design sidecar. Leave blank so start.bat enables it when
+# Docker GPU support is available and disables it on CPU-only starts.
+INDTEXTS_SFX_ENABLED=
 INDTEXTS_SFX_HOST_PORT=8020
 SFX_DEVICE=cuda
 SFX_ALLOW_CPU_FALLBACK=false

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Turn your scripts into finished multi-speaker audio, complete with emotion, soun
 
 ![Draft to Take app preview](media/draft-to-take-20s-app-clip.gif)
 
-Formerly **IndexTTS Workflow Studio**. This repository now hosts the Docker beta launcher for Draft to Take, the next-generation version of the original prototype.
+Formerly **IndexTTS Workflow Studio**. This repository is the public Docker beta launcher for Draft to Take, the next-generation version of the original prototype.
 
 ## The Workflow
 
@@ -111,7 +111,7 @@ If you are testing the beta for the first time, start with the manuals:
 
 ## Beta Status
 
-`v3.0.0-beta.7` is ready for a small closed beta with Docker-capable testers.
+`v3.0.0-beta.8` is ready for a small closed beta with Docker-capable testers.
 
 All beta container images are public and pullable from GitHub Container Registry:
 
@@ -154,7 +154,7 @@ The launcher:
 - Checks whether Docker can see your NVIDIA GPU.
 - Pulls the prebuilt beta images.
 - Starts the backend, frontend, Qwen sidecar, and OmniVoice sidecar.
-- Leaves SFX/music disabled unless you opt in.
+- Starts the SFX/music sidecar automatically when Docker GPU support is available.
 - Opens the local frontend URL after a successful start.
 
 If the port values are blank in `.env`, the launcher tries nearby ports and prints the actual URLs. Keep them blank unless you need stable URLs.
@@ -185,7 +185,7 @@ Important folders:
 
 This beta does not bundle model weights. The launcher and containers download the configured models into your local shared folder or Hugging Face cache.
 
-The default install uses IndexTTS2 for dialogue, managed Qwen for emotion detection and optional script assistance, and OmniVoice for reusable voice design. SFX, ambience, and music generation are optional because those model-backed paths are heavier and license-dependent.
+The default install uses IndexTTS2 for dialogue, managed Qwen for emotion detection and optional script assistance, OmniVoice for reusable voice design, and SFX/music generation when Docker GPU support is available. SFX, ambience, and music can still be disabled because those model-backed paths are heavier and license-dependent.
 
 <details>
 <summary>Show model details</summary>
@@ -195,8 +195,8 @@ The default install uses IndexTTS2 for dialogue, managed Qwen for emotion detect
 | Dialogue TTS | `IndexTeam/IndexTTS-2` | Yes | `shared\models\checkpoints` | Main Script Canvas and timeline speech generation. The upstream bundle includes the IndexTTS2 checkpoints, tokenizer/BPE assets, emotion and speaker matrices, and related vocoder/runtime files used by IndexTTS2. |
 | Script assistant and emotion detection | `ufoym/Qwen3-8B-Q4_K_M-GGUF` / `qwen3-8b-q4_k_m.gguf` | Yes | `shared\models\llm` | Managed llama.cpp sidecar used by the optional AI Thread and by Qwen emotion-vector detection. |
 | Reusable voice design | `k2-fsa/OmniVoice` | Yes | Hugging Face cache under `shared\models\checkpoints\hf_cache` | Creates prepared voice WAVs for the Voice Studio. Final dialogue rendering still uses IndexTTS2. |
-| SFX and ambience | `AEmotionStudio/woosh-models`, default model `Woosh-DFlow` | No | `shared\models\woosh` | Optional SFX/music sidecar. `Woosh-Flow` can be selected as a slower quality option. |
-| Music beds | `facebook/musicgen-small` | No | Hugging Face cache under `shared\models\checkpoints\hf_cache` | Optional music generation through the SFX/music sidecar. |
+| SFX and ambience | `AEmotionStudio/woosh-models`, default model `Woosh-DFlow` | Yes when Docker GPU support is available | `shared\models\woosh` | SFX/music sidecar. `Woosh-Flow` can be selected as a slower quality option. |
+| Music beds | `facebook/musicgen-small` | Yes when Docker GPU support is available | Hugging Face cache under `shared\models\checkpoints\hf_cache` | Music generation through the SFX/music sidecar. |
 | Sound-cue alignment | `openai/whisper-tiny.en` | Lazy/optional | Hugging Face cache under `shared\models\checkpoints\hf_cache` | Used only when Whisper alignment is available and sound cue markers need word-timestamp alignment. |
 | Speaker similarity checks | `speechbrain/spkrec-ecapa-voxceleb` and `funasr/campplus` / `campplus_cn_common.bin` | Lazy/optional | `shared\models\pretrained` and Hugging Face cache | Used for optional speaker similarity scoring and reranking during voice prep/quality checks. |
 | Neural cleanup | DeepFilterNet via the `df` package | Lazy/optional | Docker cache volume / package cache | Used only when DeepFilterNet cleanup is selected or available through `auto` cleanup mode. Classic noise reduction can be used when it is unavailable. |
@@ -213,22 +213,23 @@ The beta starts these services by default:
 - Frontend UI.
 - Managed Qwen sidecar, used for emotion detection and the optional AI Thread.
 - OmniVoice sidecar, used for beta testing reusable voice design.
+- SFX/music sidecar, when Docker GPU support is available.
 
 Qwen is enabled by default because emotion detection depends on it. You can turn off the AI Thread in the app settings if you do not want to use the experimental assistant workflow.
 
-## Optional SFX And Music
+## SFX And Music
 
-SFX/music generation is disabled by default because the current model-backed generators are experimental, heavier, and license-dependent.
+SFX/music generation is enabled by default when Docker can see an NVIDIA GPU. The current model-backed generators are experimental, heavier, and license-dependent, so you can still turn them off.
 
-To test it, edit `.env` and set:
+To disable SFX/music, edit `.env` and set:
 
 ```text
-INDTEXTS_SFX_ENABLED=true
+INDTEXTS_SFX_ENABLED=false
 ```
 
-Then run `start.bat` again.
+Then run `start.bat` again. If Docker GPU support is not available, `start.bat` leaves SFX/music disabled unless you explicitly opt in.
 
-Only enable SFX/music if your machine has enough VRAM and you understand that generated asset rights depend on the upstream model licenses and your use case.
+Only use SFX/music if your machine has enough VRAM and you understand that generated asset rights depend on the upstream model licenses and your use case.
 
 ## Updating The Beta
 
@@ -252,7 +253,7 @@ Your shared folder under `%USERPROFILE%\DraftToTake\shared` is not deleted.
 If a new release uses a new Docker image tag, check `.env` and update:
 
 ```text
-DRAFT_TO_TAKE_IMAGE_TAG=v3.0.0-beta.7
+DRAFT_TO_TAKE_IMAGE_TAG=v3.0.0-beta.8
 ```
 
 ## Stopping
@@ -379,7 +380,7 @@ Read:
 - [BETA_TERMS.md](BETA_TERMS.md)
 - [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)
 
-SFX/music model-backed generation is optional, experimental, and license-dependent.
+SFX/music model-backed generation is experimental and license-dependent. It can be disabled with `INDTEXTS_SFX_ENABLED=false`.
 
 ## Privacy Note
 

--- a/collect-diagnostics.bat
+++ b/collect-diagnostics.bat
@@ -5,6 +5,10 @@ cd /d "%~dp0"
 
 if "%DRAFT_TO_TAKE_HOME%"=="" set "DRAFT_TO_TAKE_HOME=%USERPROFILE%\DraftToTake"
 if "%DRAFT_TO_TAKE_SHARED_DIR%"=="" set "DRAFT_TO_TAKE_SHARED_DIR=%DRAFT_TO_TAKE_HOME%\shared"
+set "DRAFT_TO_TAKE_RUNTIME_ENV=.draft-to-take-runtime.env"
+set "COMPOSE_ENV_FILES="
+if exist ".env" set "COMPOSE_ENV_FILES=--env-file .env"
+if exist "%DRAFT_TO_TAKE_RUNTIME_ENV%" set "COMPOSE_ENV_FILES=%COMPOSE_ENV_FILES% --env-file %DRAFT_TO_TAKE_RUNTIME_ENV%"
 
 set "OUT_DIR=%DRAFT_TO_TAKE_HOME%\diagnostics"
 if not exist "%OUT_DIR%" mkdir "%OUT_DIR%"
@@ -33,28 +37,28 @@ echo.
     docker run --rm --gpus all nvidia/cuda:12.8.0-base-ubuntu22.04 nvidia-smi
     echo.
     echo == Compose PS ==
-    docker compose -f docker-compose.yml -f docker-compose.gpu.yml --profile llm --profile omnivoice --profile sfx ps
+    docker compose %COMPOSE_ENV_FILES% -f docker-compose.yml -f docker-compose.gpu.yml --profile llm --profile omnivoice --profile sfx ps
     echo.
     echo == Compose Frontend Port ==
-    docker compose -f docker-compose.yml -f docker-compose.gpu.yml --profile llm --profile omnivoice --profile sfx port frontend 80
+    docker compose %COMPOSE_ENV_FILES% -f docker-compose.yml -f docker-compose.gpu.yml --profile llm --profile omnivoice --profile sfx port frontend 80
     echo.
     echo == Compose Backend Port ==
-    docker compose -f docker-compose.yml -f docker-compose.gpu.yml --profile llm --profile omnivoice --profile sfx port backend 8000
+    docker compose %COMPOSE_ENV_FILES% -f docker-compose.yml -f docker-compose.gpu.yml --profile llm --profile omnivoice --profile sfx port backend 8000
     echo.
     echo == Backend Logs ==
-    docker compose -f docker-compose.yml -f docker-compose.gpu.yml --profile llm --profile omnivoice --profile sfx logs --tail 250 backend
+    docker compose %COMPOSE_ENV_FILES% -f docker-compose.yml -f docker-compose.gpu.yml --profile llm --profile omnivoice --profile sfx logs --tail 250 backend
     echo.
     echo == Frontend Logs ==
-    docker compose -f docker-compose.yml -f docker-compose.gpu.yml --profile llm --profile omnivoice --profile sfx logs --tail 100 frontend
+    docker compose %COMPOSE_ENV_FILES% -f docker-compose.yml -f docker-compose.gpu.yml --profile llm --profile omnivoice --profile sfx logs --tail 100 frontend
     echo.
     echo == Script LLM Logs ==
-    docker compose -f docker-compose.yml -f docker-compose.gpu.yml --profile llm logs --tail 150 script-llm
+    docker compose %COMPOSE_ENV_FILES% -f docker-compose.yml -f docker-compose.gpu.yml --profile llm logs --tail 150 script-llm
     echo.
     echo == OmniVoice Logs ==
-    docker compose -f docker-compose.yml -f docker-compose.gpu.yml --profile omnivoice logs --tail 150 omnivoice
+    docker compose %COMPOSE_ENV_FILES% -f docker-compose.yml -f docker-compose.gpu.yml --profile omnivoice logs --tail 150 omnivoice
     echo.
     echo == SFX Logs ==
-    docker compose -f docker-compose.yml -f docker-compose.gpu.yml --profile sfx logs --tail 150 sfx
+    docker compose %COMPOSE_ENV_FILES% -f docker-compose.yml -f docker-compose.gpu.yml --profile sfx logs --tail 150 sfx
 ) > "%OUT_FILE%" 2>&1
 
 echo [INFO] Diagnostics collected.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: draft-to-take-beta
 
 services:
   backend:
-    image: "${DRAFT_TO_TAKE_IMAGE_PREFIX:-ghcr.io/jayspiffy}/draft-to-take-backend:${DRAFT_TO_TAKE_IMAGE_TAG:-v3.0.0-beta.7}"
+    image: "${DRAFT_TO_TAKE_IMAGE_PREFIX:-ghcr.io/jayspiffy}/draft-to-take-backend:${DRAFT_TO_TAKE_IMAGE_TAG:-v3.0.0-beta.8}"
     container_name: draft-to-take-beta-backend
     restart: unless-stopped
     ports:
@@ -42,6 +42,8 @@ services:
       INDTEXTS_VRAM_GUARD_POLL_SECONDS: ${INDTEXTS_VRAM_GUARD_POLL_SECONDS:-2}
       INDTEXTS_VRAM_GUARD_UNLOAD_IDLE_LM_STUDIO: ${INDTEXTS_VRAM_GUARD_UNLOAD_IDLE_LM_STUDIO:-true}
       INDTEXTS_VRAM_GUARD_UNLOAD_MANUAL_LM_STUDIO: ${INDTEXTS_VRAM_GUARD_UNLOAD_MANUAL_LM_STUDIO:-false}
+      HF_HOME: /app/shared/models/checkpoints/hf_cache
+      HF_HUB_CACHE: /app/shared/models/checkpoints/hf_cache
       HF_TOKEN: ${HF_TOKEN:-}
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:8000/health | grep -q '\"status\":\"healthy\"'"]
@@ -54,7 +56,7 @@ services:
 
   script-llm:
     profiles: ["llm"]
-    image: "${DRAFT_TO_TAKE_IMAGE_PREFIX:-ghcr.io/jayspiffy}/draft-to-take-script-llm:${DRAFT_TO_TAKE_IMAGE_TAG:-v3.0.0-beta.7}"
+    image: "${DRAFT_TO_TAKE_IMAGE_PREFIX:-ghcr.io/jayspiffy}/draft-to-take-script-llm:${DRAFT_TO_TAKE_IMAGE_TAG:-v3.0.0-beta.8}"
     container_name: draft-to-take-beta-script-llm
     restart: unless-stopped
     ports:
@@ -90,7 +92,7 @@ services:
 
   sfx:
     profiles: ["sfx"]
-    image: "${DRAFT_TO_TAKE_IMAGE_PREFIX:-ghcr.io/jayspiffy}/draft-to-take-sfx:${DRAFT_TO_TAKE_IMAGE_TAG:-v3.0.0-beta.7}"
+    image: "${DRAFT_TO_TAKE_IMAGE_PREFIX:-ghcr.io/jayspiffy}/draft-to-take-sfx:${DRAFT_TO_TAKE_IMAGE_TAG:-v3.0.0-beta.8}"
     container_name: draft-to-take-beta-sfx
     restart: unless-stopped
     ports:
@@ -144,7 +146,7 @@ services:
 
   omnivoice:
     profiles: ["omnivoice"]
-    image: "${DRAFT_TO_TAKE_IMAGE_PREFIX:-ghcr.io/jayspiffy}/draft-to-take-omnivoice:${DRAFT_TO_TAKE_IMAGE_TAG:-v3.0.0-beta.7}"
+    image: "${DRAFT_TO_TAKE_IMAGE_PREFIX:-ghcr.io/jayspiffy}/draft-to-take-omnivoice:${DRAFT_TO_TAKE_IMAGE_TAG:-v3.0.0-beta.8}"
     container_name: draft-to-take-beta-omnivoice
     restart: unless-stopped
     ports:
@@ -173,7 +175,7 @@ services:
       - draft-to-take-beta-network
 
   frontend:
-    image: "${DRAFT_TO_TAKE_IMAGE_PREFIX:-ghcr.io/jayspiffy}/draft-to-take-frontend:${DRAFT_TO_TAKE_IMAGE_TAG:-v3.0.0-beta.7}"
+    image: "${DRAFT_TO_TAKE_IMAGE_PREFIX:-ghcr.io/jayspiffy}/draft-to-take-frontend:${DRAFT_TO_TAKE_IMAGE_TAG:-v3.0.0-beta.8}"
     container_name: draft-to-take-beta-frontend
     restart: unless-stopped
     ports:

--- a/start.bat
+++ b/start.bat
@@ -78,18 +78,19 @@ if errorlevel 1 (
     echo           SFX/music generation is disabled unless you opt in manually.
     set "INDTEXTS_USE_GPU=false"
     set "INDTEXTS_DEVICE=cpu"
+    if "%INDTEXTS_SFX_ENABLED%"=="" set "INDTEXTS_SFX_ENABLED=false"
     set "COMPOSE_FILES=-f docker-compose.yml"
 ) else (
     echo [INFO] NVIDIA GPU detected.
     set "INDTEXTS_USE_GPU=true"
     if "%INDTEXTS_DEVICE%"=="" set "INDTEXTS_DEVICE=auto"
     if "%INDTEXTS_USE_DEEPSPEED%"=="" set "INDTEXTS_USE_DEEPSPEED=true"
+    if "%INDTEXTS_SFX_ENABLED%"=="" set "INDTEXTS_SFX_ENABLED=true"
     set "COMPOSE_FILES=-f docker-compose.yml -f docker-compose.gpu.yml"
 )
 
 if "%INDTEXTS_SCRIPT_LLM_ENABLED%"=="" set "INDTEXTS_SCRIPT_LLM_ENABLED=true"
 if "%INDTEXTS_OMNIVOICE_ENABLED%"=="" set "INDTEXTS_OMNIVOICE_ENABLED=true"
-if "%INDTEXTS_SFX_ENABLED%"=="" set "INDTEXTS_SFX_ENABLED=false"
 
 set "COMPOSE_PROFILES_ARGS="
 if /I not "%INDTEXTS_SCRIPT_LLM_ENABLED%"=="false" (
@@ -108,9 +109,9 @@ if /I not "%INDTEXTS_OMNIVOICE_ENABLED%"=="false" (
 
 if /I "%INDTEXTS_SFX_ENABLED%"=="true" (
     set "COMPOSE_PROFILES_ARGS=%COMPOSE_PROFILES_ARGS% --profile sfx"
-    echo [WARNING] SFX/music sidecar enabled. These model-backed tools are experimental and license-dependent.
+    echo [INFO] SFX/music sidecar: enabled
 ) else (
-    echo [INFO] SFX/music sidecar: disabled by default for beta
+    echo [INFO] SFX/music sidecar: disabled
 )
 
 echo.

--- a/start.bat
+++ b/start.bat
@@ -57,12 +57,6 @@ if "%INDTEXTS_BACKEND_HOST_PORT%"=="" (
     exit /b 1
 )
 
-(
-    echo INDTEXTS_FRONTEND_HOST_PORT=%INDTEXTS_FRONTEND_HOST_PORT%
-    echo INDTEXTS_BACKEND_HOST_PORT=%INDTEXTS_BACKEND_HOST_PORT%
-    echo DRAFT_TO_TAKE_SHARED_DIR=%DRAFT_TO_TAKE_SHARED_DIR%
-) > "%DRAFT_TO_TAKE_RUNTIME_ENV%"
-
 docker info >nul 2>&1
 if errorlevel 1 (
     echo [ERROR] Docker is not running. Please start Docker Desktop and try again.
@@ -114,12 +108,26 @@ if /I "%INDTEXTS_SFX_ENABLED%"=="true" (
     echo [INFO] SFX/music sidecar: disabled
 )
 
+(
+    echo INDTEXTS_FRONTEND_HOST_PORT=%INDTEXTS_FRONTEND_HOST_PORT%
+    echo INDTEXTS_BACKEND_HOST_PORT=%INDTEXTS_BACKEND_HOST_PORT%
+    echo DRAFT_TO_TAKE_SHARED_DIR=%DRAFT_TO_TAKE_SHARED_DIR%
+    echo INDTEXTS_USE_GPU=%INDTEXTS_USE_GPU%
+    echo INDTEXTS_DEVICE=%INDTEXTS_DEVICE%
+    echo INDTEXTS_USE_DEEPSPEED=%INDTEXTS_USE_DEEPSPEED%
+    echo INDTEXTS_SCRIPT_LLM_ENABLED=%INDTEXTS_SCRIPT_LLM_ENABLED%
+    echo INDTEXTS_OMNIVOICE_ENABLED=%INDTEXTS_OMNIVOICE_ENABLED%
+    echo INDTEXTS_SFX_ENABLED=%INDTEXTS_SFX_ENABLED%
+) > "%DRAFT_TO_TAKE_RUNTIME_ENV%"
+
+set "COMPOSE_ENV_FILES=--env-file .env --env-file %DRAFT_TO_TAKE_RUNTIME_ENV%"
+
 echo.
 echo [INFO] Shared files live here:
 echo        %DRAFT_TO_TAKE_SHARED_DIR%
 echo.
 echo [INFO] Pulling and starting Draft to Take beta images...
-docker compose %COMPOSE_FILES% %COMPOSE_PROFILES_ARGS% pull
+docker compose %COMPOSE_ENV_FILES% %COMPOSE_FILES% %COMPOSE_PROFILES_ARGS% pull
 if errorlevel 1 (
     echo [ERROR] Docker image pull failed.
     echo         If these are GHCR images, confirm the packages are public or run docker login ghcr.io.
@@ -127,7 +135,7 @@ if errorlevel 1 (
     exit /b 1
 )
 
-docker compose %COMPOSE_FILES% %COMPOSE_PROFILES_ARGS% up -d
+docker compose %COMPOSE_ENV_FILES% %COMPOSE_FILES% %COMPOSE_PROFILES_ARGS% up -d
 if errorlevel 1 (
     echo [ERROR] Docker Compose failed to start the beta stack.
     pause
@@ -135,6 +143,7 @@ if errorlevel 1 (
 )
 
 call :CheckComposePort backend 8000 DRAFT_TO_TAKE_BACKEND_BINDING
+if /I "%DRAFT_TO_TAKE_BACKEND_BINDING%"=="invalid IP:0" set "DRAFT_TO_TAKE_BACKEND_BINDING="
 if "%DRAFT_TO_TAKE_BACKEND_BINDING%"=="" (
     echo [ERROR] Backend container started, but Docker did not publish its host port.
     echo         Run collect-diagnostics.bat and include the Compose PS section in your bug report.
@@ -143,16 +152,18 @@ if "%DRAFT_TO_TAKE_BACKEND_BINDING%"=="" (
 )
 
 call :CheckComposePort frontend 80 DRAFT_TO_TAKE_FRONTEND_BINDING
+if /I "%DRAFT_TO_TAKE_FRONTEND_BINDING%"=="invalid IP:0" set "DRAFT_TO_TAKE_FRONTEND_BINDING="
 if "%DRAFT_TO_TAKE_FRONTEND_BINDING%"=="" (
     echo [WARNING] Frontend container is running, but Docker did not publish its browser port.
     echo           Recreating the frontend container to repair the port binding...
-    docker compose %COMPOSE_FILES% %COMPOSE_PROFILES_ARGS% up -d --force-recreate frontend
+    docker compose %COMPOSE_ENV_FILES% %COMPOSE_FILES% %COMPOSE_PROFILES_ARGS% up -d --force-recreate frontend
     if errorlevel 1 (
         echo [ERROR] Frontend recreate failed.
         pause
         exit /b 1
     )
     call :CheckComposePort frontend 80 DRAFT_TO_TAKE_FRONTEND_BINDING
+    if /I "%DRAFT_TO_TAKE_FRONTEND_BINDING%"=="invalid IP:0" set "DRAFT_TO_TAKE_FRONTEND_BINDING="
 )
 
 if "%DRAFT_TO_TAKE_FRONTEND_BINDING%"=="" (
@@ -190,14 +201,14 @@ if /I not "%DRAFT_TO_TAKE_OPEN_BROWSER%"=="false" (
 )
 
 timeout /t 5 /nobreak >nul
-docker compose %COMPOSE_FILES% %COMPOSE_PROFILES_ARGS% logs backend --tail 30
+docker compose %COMPOSE_ENV_FILES% %COMPOSE_FILES% %COMPOSE_PROFILES_ARGS% logs backend --tail 30
 
 pause
 exit /b 0
 
 :CheckComposePort
 set "%~3="
-for /f "tokens=* delims=" %%i in ('docker compose %COMPOSE_FILES% %COMPOSE_PROFILES_ARGS% port %~1 %~2 2^>nul') do (
+for /f "tokens=* delims=" %%i in ('docker compose %COMPOSE_ENV_FILES% %COMPOSE_FILES% %COMPOSE_PROFILES_ARGS% port %~1 %~2 2^>nul') do (
     if not defined %~3 set "%~3=%%i"
 )
 exit /b 0


### PR DESCRIPTION
## Summary
- Bumps the public IndexTTS Workflow Studio / Draft to Take launcher from beta 7 to beta 8 images.
- Keeps this repository positioned as the public beta launcher for Draft to Take.
- Enables SFX/music by default when Docker GPU support is available, while leaving it disabled on CPU-only starts.
- Persists backend Hugging Face cache under the shared model folder.

## Why
Issue #7 showed the beta 7 frontend could be healthy inside Docker while not being published to a Windows browser port. The current launcher already checks frontend port binding; this PR moves the public repo to the beta 8 image set and keeps the docs aligned with the GPU-aware Full Studio default.

## Validation
- `docker compose -f docker-compose.yml -f docker-compose.gpu.yml --profile llm --profile omnivoice --profile sfx config --format json`